### PR TITLE
112 slurm backend args from application config

### DIFF
--- a/jetstream/__init__.py
+++ b/jetstream/__init__.py
@@ -50,9 +50,9 @@ def lookup_backend(name=None):
     will return the class and also a dictionary of default paramters for
     instantiating the class that can be customized via config file."""
     name = name or settings['backend'].get(str)
-    params = settings['backends'][name].get(dict).copy()
-    cls = params.pop('()')
-    backend = utils.dynamic_import(cls)
+    params = settings['backends'][name].flatten()
+    class_path = params.pop('()')
+    backend = utils.dynamic_import(class_path)
     return backend, params
 
 
@@ -80,7 +80,7 @@ def start_logging(profile=None):
             profile = 'basic'
 
     profile = str(profile).lower()
-    config = settings['logging_profiles'][profile].get(dict)
+    config = settings['logging_profiles'][profile].flatten()
     logging.config.dictConfig(config)
     log.debug(f'Logging started: {profile}')
 

--- a/jetstream/backends/local.py
+++ b/jetstream/backends/local.py
@@ -22,7 +22,7 @@ class LocalBackend(jetstream.backends.BaseBackend):
         """
         super(LocalBackend, self).__init__()
         self.cpus = cpus \
-                    or jetstream.settings['backends']['local']['cpus'] \
+                    or jetstream.settings['backends']['local']['cpus'].get() \
                     or jetstream.utils.guess_local_cpus()
         self.bip = blocking_io_penalty \
                    or jetstream.settings['backends']['local']['blocking_io_penalty'].get(int)

--- a/jetstream/backends/slurm.py
+++ b/jetstream/backends/slurm.py
@@ -29,9 +29,14 @@ class SlurmBackend(BaseBackend):
     respects = ('cmd', 'stdin', 'stdout', 'stderr', 'cpus', 'mem', 'walltime',
                 'slurm_args')
 
-    def __init__(self, sacct_frequency=60, sbatch_delay=0.1,
-                 sbatch_executable=None, sacct_fields=('JobID', 'Elapsed'),
-                 job_monitor_max_fails=5):
+    def __init__(
+            self,
+            sacct_frequency=60,
+            sbatch_args=None,
+            sbatch_delay=0.1,
+            sbatch_executable=None,
+            sacct_fields=('JobID', 'Elapsed'),
+            job_monitor_max_fails=5):
         """SlurmBackend submits tasks as jobs to a Slurm batch cluster
 
         :param sacct_frequency: Frequency in seconds that job updates will
@@ -39,6 +44,7 @@ class SlurmBackend(BaseBackend):
         :param sbatch: path to the sbatch binary if not on PATH
         """
         super(SlurmBackend, self).__init__()
+        self.sbatch_args = sbatch_args
         self.sbatch_executable = sbatch_executable
         self.sacct_frequency = sacct_frequency
         self.sacct_fields = sacct_fields
@@ -156,9 +162,24 @@ class SlurmBackend(BaseBackend):
         if not task.directives.get('cmd'):
             return task.complete()
 
-        # sbatch breaks when called too frequently
+        # sbatch breaks when called too frequently, so this places
+        # a hard limit on the frequency of sbatch calls.
         time.sleep(self.sbatch_delay)
+
         stdin, stdout, stderr = self.get_fd_paths(task)
+
+        # Any additional sbatch args will come from the application
+        # settings, followed by task settings. This means task settings
+        # will be able to override application config settings.
+        sbatch_args = self.sbatch_args
+        if isinstance(sbatch_args, str):
+            sbatch_args = [sbatch_args,]
+
+        task_sbatch_args = task.directives.get('sbatch_args', [])
+        if isinstance(task_sbatch_args, str):
+            task_sbatch_args = [task_sbatch_args,]
+
+        sbatch_args.extend(task_sbatch_args)
 
         job = sbatch(
             cmd=task.directives['cmd'],
@@ -170,7 +191,7 @@ class SlurmBackend(BaseBackend):
             cpus_per_task=task.directives.get('cpus'),
             mem=task.directives.get('mem'),
             walltime=task.directives.get('walltime'),
-            additional_args=task.directives.get('sbatch_args'),
+            additional_args=sbatch_args,
             sbatch_executable=self.sbatch_executable
         )
 

--- a/jetstream/cli/__init__.py
+++ b/jetstream/cli/__init__.py
@@ -35,12 +35,12 @@ class ConfigAction(argparse.Action):
     """ConfigAction is an argparse action that allows an arbitrary configuration
     object to be built entirely from command arguments. An example for how to
     use these actions is included in add_config_options_to_parser().
-    
+
     If this action was assigned to the argument "-c/--config":
 
-    <cmd> -c int:answer 42 -c str:foo 42 
+    <cmd> -c int:answer 42 -c str:foo 42
 
-    When parsed, these args would add a dictionary to the argparse namespace 
+    When parsed, these args would add a dictionary to the argparse namespace
     destination "config":
 
     args = parser.parse_arguments()
@@ -58,7 +58,7 @@ class ConfigAction(argparse.Action):
     }
 
     loaders = {}
-    _default_loaders = {}  
+    _default_loaders = {}
 
     def __init__(self, delim=':', *args, **kwargs):
         self.delim = delim
@@ -85,7 +85,7 @@ class ConfigAction(argparse.Action):
                 fn = self.loaders[var_type[5:]]
             else:
                 fn = self.parsers[var_type]
-        except KeyError:  
+        except KeyError:
             msg = f'No function found for "{var_type}". Available types' \
                   f'are: {", ".join(self.get_type_choices())}'
             raise argparse.ArgumentError(self, msg)
@@ -165,7 +165,7 @@ def arg_parser():
 
     common.add_argument(
         '-l', '--logging',
-        choices=jetstream.settings['logging_profiles'].get(dict),
+        choices=jetstream.settings['logging_profiles'].flatten(),
         help='set the logging profile [interactive]'
     )
 
@@ -242,11 +242,11 @@ def main(args=None):
         if args.config_file:
             if args.config_file_type:
                 config_file = jetstream.utils.load_file(
-                    args.config_file, 
+                    args.config_file,
                     filetype=args.config_file_type
                 )
             else:
-                config_file = jetstream.utils.load_file(args.config_file)     
+                config_file = jetstream.utils.load_file(args.config_file)
             if not isinstance(config_file, dict):
                 final = {'__config_file__': config_file}
             else:

--- a/jetstream/cli/subcommands/run_common_options.py
+++ b/jetstream/cli/subcommands/run_common_options.py
@@ -29,7 +29,7 @@ def add_arguments(parser):
 
     group.add_argument(
         '--backend',
-        choices=jetstream.settings['backends'].get(dict),
+        choices=jetstream.settings['backends'].flatten(),
         default=jetstream.settings['backend'].get(str),
         help='runner backend name used for executing tasks [%(default)s]'
     )


### PR DESCRIPTION
This patch fixes some issues with config files, and adds `sbatch_args` as a config value for the SlurmBackend. 

# Modifying nested config values caused problems

For example, given the config defaults here:

```yaml
backends:
  local:
    (): jetstream.backends.local.LocalBackend
    blocking_io_penalty: 30
    cpus: null
```

If a user attempted to modify the cpus value:

```
backends:
  local:
    cpus: 4
```

The other values would have been lost, and an error would be raised when instantiating the backend class, like this:

```
...
  File "/home/rrichholt/jetstream/jetstream/runner.py", line 44, in __init__
    self.backend_cls, self.backend_params = jetstream.lookup_backend(backend)
  File "/home/rrichholt/jetstream/jetstream/__init__.py", line 55, in lookup_backend
    cls = params.pop('()')
KeyError: '()'
```

This was fixed by flattening nested items when pulling entire sections of config values.


# `sbatch_args` in config file

Here's an example that demonstrates adding extra sbatch args in the user config file:

```
backend: slurm
backends:
  slurm:
    sbatch_args: ['-J', 'foo']
```

When launching jobs the final `sbatch` command is built like this:

```
sbatch <options from task directives> <config sbatch_args> <task sbatch_args>  task.sh
```

This means task specific sbatch_args will override values from the config file. But, config args will override default behaviors. 

Given this task:

```
- name: taskA
  cmd: echo hello world
```

and this user config file:

```
backend: slurm
backends:
  slurm:
    sbatch_args: ['-J', 'foo']
```

the final command would look something like this:
```
sbatch --parsable -J hello_world --comment '{"id":"c981cd73751594856f6b04ce4b947b72e1090b8e", "tags": []} -J foo /scratch/rrichholt/tmp/tmpnwegwnql
```

Notice the `-J` option set twice. But, the last option takes precedence and the job name is "foo"
