### PR TITLE
Update python requirement to 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ jetstream tasks -v
 > TGen users on Diamondback can load the latest version of Python with 
   `module load python`.
 
-This is a Python package and requires Python3. Installation guides for 
+This is a Python package and requires Python3 (>=3.6). Installation guides for 
 Mac/Windows/Linux are available from the 
 [Hitchiker's Guide to Python][install_help] After Python3 is installed, you can 
 install Jetstream with Pip (next step).

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     keywords='ngs pipeline automation',
     packages=find_packages(exclude=('tests',)),
     include_package_data=True,
-    python_requires='>=3',
+    python_requires='>=3.6',
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Topic :: Utilities',


### PR DESCRIPTION
As pointed out by the @parallelworks team, we use features that did not exist prior to python 3.6. Our requirement should be updated accordingly.