### PR TITLE
Mash only feature update

### DIFF
--- a/jetstream/cli/subcommands/run.py
+++ b/jetstream/cli/subcommands/run.py
@@ -116,6 +116,12 @@ def run(wf, args):
 
     wf.reset(args.reset_method)
 
+    if args.mash_only:
+        if args.out:
+            wf.save(args.out)
+        log.info('Mashed workflow built successfully!')
+        return
+
     try:
         args.runner.start(
             workflow=wf,

--- a/jetstream/cli/subcommands/run_common_options.py
+++ b/jetstream/cli/subcommands/run_common_options.py
@@ -16,6 +16,12 @@ def add_arguments(parser):
     )
 
     group.add_argument(
+        '-m', '--mash-only',
+        action='store_true',
+        help='just render the template, build the workflow, mash with an existing workflow, and stop'
+    )
+
+    group.add_argument(
         '-b', '--build-only',
         action='store_true',
         help='just render the template, build the workflow, and stop'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -104,13 +104,48 @@ class TestCli(TestCase):
         cli_main(args)
 
     def test_run_w_vars(self):
-        """run simple wokrflow with a couple variables passed as args"""
+        """run simple workflow with a couple variables passed as args"""
         with open('testwf.jst', 'w') as fp:
             fp.write('- cmd: echo {{ name }}\n  stdout: /dev/null\n')
 
         args = [
             'run',
             'testwf.jst',
+            '-c', 'str:name', 'Philip J. Fry',
+            '-c', 'bool:ok', 'true',
+            '-c', 'int:number', '42',
+            '-c', 'float:number2', '3.14'
+        ]
+
+        cli_main(args)
+
+    def test_run_w_mash(self):
+        """run the first workflow and then mash in the second workflow"""
+        with open('testwf1.jst', 'w') as fp:
+            fp.write('- name: task1\n  cmd: echo {{ name }}\n  stdout: /dev/null\n')
+
+        with open('testwf2.jst', 'w') as fp:
+            fp.write('- name: task1\n  cmd: echo {{ number }}\n  stdout: /dev/null\n')
+            fp.write('- name: task2\n  cmd: echo {{ number2 }}\n  stdout: /dev/null\n')
+
+        args = [
+            'run',
+            'testwf1.jst',
+            '-o', 'workflow.pickle',
+            '-c', 'str:name', 'Philip J. Fry',
+            '-c', 'bool:ok', 'true',
+            '-c', 'int:number', '42',
+            '-c', 'float:number2', '3.14'
+        ]
+
+        cli_main(args)
+
+        args = [
+            'run',
+            'testwf2.jst',
+            '-w', 'workflow.pickle',
+            '-m',
+            '-o', 'new_workflow.pickle',
             '-c', 'str:name', 'Philip J. Fry',
             '-c', 'bool:ok', 'true',
             '-c', 'int:number', '42',


### PR DESCRIPTION
This feature is helpful for pre-mashing projects to check which tasks will be updated and or reset. Also needed for implementing smart copy functionality, which checks the mashed workflow's inputs and outputs to decided what needs to copied down from the archive space, saving on disk usage and compute time for decompressing projects which do not need to be decompressed.