### PR TITLE
fixed sbatch args handling and updated test cases

### DIFF
--- a/jetstream/tasks.py
+++ b/jetstream/tasks.py
@@ -268,7 +268,7 @@ def copy(task):
 def random_task(name=None, input=None):
     if name is None:
         name = jetstream.guid(formatter='random_task_{id}')
-    cmd = 'set -ue\n\nhostname\n\n\date\necho {} is running'
+    cmd = 'set -ue\n\nhostname\n\ndate\necho {} is running'
     output = name + '.txt'
     return Task(name=name, cmd=cmd, input=input, output=output)
 

--- a/tests/templates/slurm.jst
+++ b/tests/templates/slurm.jst
@@ -1,0 +1,33 @@
+# Tests slurm options
+- name: hello
+  description: The slurm job name should be "hello world", even thought The
+    task id is just "hello"
+  sbatch_args: -J "hello world"
+  cmd: |
+    if [ -z "${SLURM_JOB_NAME}" ]; then
+        echo "not running on a slurm cluster"
+    else
+        if [ "${SLURM_JOB_NAME}" != "hello world" ]; then
+            echo "wrong job name: ${SLURM_JOB_NAME}"
+            exit 1
+        else
+            echo "job name is correct: ${SLURM_JOB_NAME}"
+        fi
+    fi
+
+
+- name: hello2
+  description: sbatch_args should also support sequences
+  sbatch_args: [-J, hello world 2]
+  cmd: |
+    if [ -z "${SLURM_JOB_NAME}" ]; then
+        echo "not running on a slurm cluster"
+    else
+        if [ "${SLURM_JOB_NAME}" != "hello world 2" ]; then
+            echo "wrong job name: ${SLURM_JOB_NAME}"
+            e
+            exit 1
+        else
+            echo "job name is correct: ${SLURM_JOB_NAME}"
+        fi
+    fi

--- a/tests/test_run_templates.py
+++ b/tests/test_run_templates.py
@@ -18,7 +18,7 @@ try:
         stderr=subprocess.STDOUT,
     )
     is_sbatch_available = True
-except subprocess.CalledProcessError:
+except FileNotFoundError:
     is_sbatch_available = False
 
 local_tests = {


### PR DESCRIPTION
This PR updates the code for handling sbatch_args directives and application settings. It also updates the templates test cases so that they run on both local and slurm backends. This idea could be extended to cover test pipelines in the future. This should prevent some backend-specific bugs from going untested.