### PR TITLE
Bugfix/exec directive context

### DIFF
--- a/jetstream/backends/slurm.py
+++ b/jetstream/backends/slurm.py
@@ -446,11 +446,11 @@ def launch_sacct(*job_ids, delimiter=sacct_delimiter, raw=False):
 def parse_sacct(data, delimiter=sacct_delimiter, id_pattern=job_id_pattern):
     """Parse stdout from sacct to a dictionary of job ids and data."""
     jobs = dict()
-    lines = iter(data.strip().splitlines())
-    header = next(lines).strip().split(delimiter)
+    lines = iter(data.splitlines())
+    header = next(lines).split(delimiter)
 
     for line in lines:
-        row = dict(zip(header, line.strip().split(delimiter)))
+        row = dict(zip(header, line.split(delimiter)))
 
         try:
             match = id_pattern.match(row['JobID'])

--- a/jetstream/pipelines.py
+++ b/jetstream/pipelines.py
@@ -163,7 +163,7 @@ def find_pipelines(*dirs):
                     p = Pipeline(path)
                     log.debug(f'Found {p} at {path}')
                     yield p
-                except :
+                except Exception:
                     log.debug(f'Failed to load: {path}')
 
                 yield from find_pipelines(path)

--- a/jetstream/runner.py
+++ b/jetstream/runner.py
@@ -237,8 +237,7 @@ class Runner:
         exec_directive = task.directives.get('exec')
 
         if exec_directive:
-            env = {'runner': self, 'task': task}
-            exec(exec_directive, None, env)
+            exec(exec_directive)
             self._workflow_graph = self.workflow.reload_graph()
             self._workflow_iterator = iter(self.workflow.graph)
 

--- a/tests/templates/dependencies_3.jst
+++ b/tests/templates/dependencies_3.jst
@@ -1,16 +1,16 @@
-# This template tests dynamic features with the exec directive. 
+# This template tests dynamic features with the exec directive.
 # During a run, add_tasks will add a new to the workflow. The
-# last task will wait for the new task to complete via the 
+# last task will wait for the new task to complete via the
 # after-re directive.
 # Expected stdout: "Hello, world! All done!"
 - name: start
-  cmd: printf 'Hello, ' 
+  cmd: printf 'Hello, '
 
 
 - name: add_tasks
   after: start
   exec: |
-    runner.workflow.new_task(
+    self.workflow.new_task(
         name='dynamic_task',
         cmd="printf 'world! '"
     )


### PR DESCRIPTION
This PR fixes two bugs that I've found while using Jetstream: 
- Fixes #131 - The first is related to handling exec directives. Functions defined within an exec directive were not seeing some values imported within the same directive. From the docs: "If exec gets two separate objects as globals and locals, the code will be executed as if it were embedded in a class definition." The fix here is to not supply values for these and just use the current scope. This requires small changes to templates using `runner` within exec directives, see the test template for an example.
- On some clusters, no values are set for the "account". When parsing sacct output, this caused the first two fields of the output table to be removed, and broke the parser. This was fixed by not stripping whitespace from the lines to be parsed.
