### PR TITLE
Backend updates

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -11,10 +11,10 @@ comparisons, or documenting the tasks)
 
 ## Identity
 
-The identity of a task is a hash of `cmd` and `exec` directives. This identity
-is used to compare tasks against the saved progress records. If the task 
-identity has changed, the task will need to be reset along with any downstream
-tasks. 
+The identity of a task is a hash of `cmd`, `exec`, `container`, and `digest` 
+directives. This identity is used to compare tasks against the saved progress 
+records. If the task identity has changed, the task will need to be reset along 
+with any downstream tasks. 
 
 Identity is a good indicator that tasks have changed and will need to be re-run,
 but it's possible to make changes to a template that go undetected. Understanding 

--- a/jetstream/config_default.yaml
+++ b/jetstream/config_default.yaml
@@ -133,6 +133,29 @@ slurm_active_states:
 slurm_passed_states:
   - COMPLETED
 
+# This helps decide the formatting of sbatch scripts in the slurm_singularity 
+# backend. Some of these could interfere with jetstreams submission behavior.
+# Options such as --usage, --help, --version, --wait should probably be
+# globally disabled.
+slurm_solo_options:
+  - --exclusive
+  - --get-user-env
+  - --no-kill
+  - --no-requeue
+  - --overcommit
+  - --parsable
+  - --quiet
+  - --requeue
+  - --oversubscribe
+  - --spread-job
+  - --use-min-nodes
+  - --contiguous
+  - --help
+  - --usage
+  - --verbose
+  - --version
+  - --wait
+
 # ================================== Pipelines ================================
 # Pipelines are a collection of pre-built workflows that are installed in the
 # pipelines:home directory. They can be run by name using the jetstream

--- a/jetstream/pipelines.py
+++ b/jetstream/pipelines.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from distutils.version import LooseVersion
+from packaging.version import parse as parse_version
 import jetstream
 
 log = logging.getLogger(__name__)
@@ -183,14 +183,14 @@ def get_pipeline(name, version=None, searchpath=None):
                 matches.append(p)
 
         if matches:
-            s = sorted(matches, key=lambda p: LooseVersion(p.version))
+            s = sorted(matches, key=lambda p: parse_version(p.version))
             return s[-1]
     else:
         # Find a match with name and version
-        version = str(version)
+        # version = LooseVersion(str(version))
         for p in find_pipelines(*searchpath):
             # TODO can we allow > < = syntax here?
-            if p.name == name and LooseVersion(p.version) == LooseVersion(version):
+            if p.name == name and parse_version(p.version) == parse_version(version):
                 return p
 
 

--- a/jetstream/pipelines.py
+++ b/jetstream/pipelines.py
@@ -187,10 +187,9 @@ def get_pipeline(name, version=None, searchpath=None):
             return s[-1]
     else:
         # Find a match with name and version
-        # version = LooseVersion(str(version))
         for p in find_pipelines(*searchpath):
             # TODO can we allow > < = syntax here?
-            if p.name == name and parse_version(p.version) == parse_version(version):
+            if p.name == name and parse_version(str(p.version)) == parse_version(str(version)):
                 return p
 
 

--- a/jetstream/workflows.py
+++ b/jetstream/workflows.py
@@ -26,7 +26,7 @@ import re
 import shutil
 from collections import Counter, deque
 from datetime import datetime
-from distutils.version import LooseVersion
+from packaging.version import parse as parse_version
 import networkx as nx
 import jetstream
 from jetstream import utils
@@ -81,8 +81,8 @@ class Workflow:
         self.tasks[task.name] = task
 
     def check_versions(self):
-        current_version = LooseVersion(jetstream.__version__)
-        built_w_version = LooseVersion(self.version)
+        current_version = parse_version(jetstream.__version__)
+        built_w_version = parse_version(self.version)
 
         if built_w_version > current_version:
             msg = f'This workflow was built with a newer version of ' \


### PR DESCRIPTION
This includes a small handful of changes, most notably an update for parsing a task's sbatch_args to avoid improper grouping in the generated sbatch header. This also adds the ability for a task to pass args to the slurm singularity backend. This is helpful in the case of telling singularity to mount a specific directory for a given task. 

Finally, we have a bug fix. It's not a reported issue, but it has popped up previously. distutils.version LooseVersion has some inherent issues. This is pretty well summarized by this issue: https://github.com/postmarketOS/pmbootstrap/issues/342

```python
>>> from distutils.version import LooseVersion
>>> LooseVersion("22.7-r1") < LooseVersion("22.7.3-r1")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.6/distutils/version.py", line 52, in __lt__
    c = self._cmp(other)
  File "/usr/lib/python3.6/distutils/version.py", line 337, in _cmp
    if self.version < other.version:
TypeError: '<' not supported between instances of 'str' and 'int'
```

In our case we've had this pop up when comparing fastqGeneration@1.3.0 and fastqGeneration@development.

Additionally LooseVersion is deprecated. As a solution to this, I've replaced LooseVersion with packaging.version parse. Which follows the PEP 440 version scheme, otherwise the version is seen as a legacy version. What this results in is that `development` is seen as a LegacyVersion and therefore is seen as the lowest version available. This behavior is actually similar to the previous implementation in practice:

```python
>>> from distutils.version import LooseVersion
>>> c = LooseVersion('development')
>>> a = LooseVersion('1.1')
>>> a > c
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/packages/python/3.6.0/lib/python3.6/distutils/version.py", line 64, in __gt__
    c = self._cmp(other)
  File "/packages/python/3.6.0/lib/python3.6/distutils/version.py", line 337, in _cmp
    if self.version < other.version:
TypeError: '<' not supported between instances of 'int' and 'str'
>>> a = LooseVersion('v1.1')
>>> a > c
True
```
