### PR TITLE
V1.7.2 improvements

### DIFF
--- a/jetstream/backends/slurm_singularity.py
+++ b/jetstream/backends/slurm_singularity.py
@@ -262,6 +262,7 @@ class SlurmSingularityBackend(BaseBackend):
             time.sleep(self.sbatch_delay)
             job = await sbatch(
                 cmd=task.directives['cmd'],
+                identity=task.identity,
                 singularity_image=singularity_image,
                 singularity_image_digest=digest,
                 singularity_executable=self.singularity_executable,
@@ -519,7 +520,7 @@ def parse_sacct(data, delimiter=SLURM_SACCT_DELIMITER, id_pattern=SLURM_JOB_ID_P
     return jobs
 
 
-async def sbatch(cmd, singularity_image, singularity_executable="singularity", 
+async def sbatch(cmd, identity, singularity_image, singularity_executable="singularity", 
                  singularity_run_sem=None, singularity_hostname=None, singularity_image_digest=None,
                  runner_args=None, runner_preset=None, docker_authentication_token=None, name=None, 
                  input_filenames=[], output_filenames=[], stdin=None, stdout=None, stderr=None, 
@@ -559,7 +560,7 @@ async def sbatch(cmd, singularity_image, singularity_executable="singularity",
     millis = int(round(time.time() * 1000))
     if name == None:
         name = "script"
-    cmd_script_filename = f"jetstream/cmd/{millis}_{name}.cmd"
+    cmd_script_filename = f"jetstream/cmd/{millis}_{identity}.cmd"
     cmd_script_filename = os.path.abspath( cmd_script_filename )
     with open( cmd_script_filename, "w" ) as cmd_script:
         cmd_script.write( cmd )
@@ -682,7 +683,7 @@ async def sbatch(cmd, singularity_image, singularity_executable="singularity",
     
     if name == None:
         name = "script"
-    sbatch_script_filename = f"jetstream/cmd/{millis}_{name}.sbatch"
+    sbatch_script_filename = f"jetstream/cmd/{millis}_{identity}.sbatch"
     sbatch_script_filename = os.path.abspath( sbatch_script_filename )
     with open( sbatch_script_filename, "w" ) as sbatch_script_file:
         sbatch_script_file.write( sbatch_script )

--- a/jetstream/backends/slurm_singularity.py
+++ b/jetstream/backends/slurm_singularity.py
@@ -660,7 +660,7 @@ async def sbatch(cmd, identity, singularity_image, singularity_executable="singu
         else:
             singularity_args.extend(runner_args)
 
-    singularity_exec_args = "--bind $PWD --pwd $PWD --cleanenv --contain"
+    singularity_exec_args = "--bind $JS_PIPELINE_PATH --bind $PWD --pwd $PWD --workdir /tmp --cleanenv --contain"
     
     for arg in singularity_args:
         singularity_exec_args += f" {arg}" 

--- a/jetstream/backends/slurm_singularity.py
+++ b/jetstream/backends/slurm_singularity.py
@@ -663,7 +663,7 @@ async def sbatch(cmd, identity, singularity_image, singularity_executable="singu
     singularity_exec_args = "--bind $PWD --pwd $PWD --cleanenv --contain"
     
     for arg in singularity_args:
-        singularity_exec_args += f"{arg} " 
+        singularity_exec_args += f" {arg}" 
 
     singularity_hostname_arg = ""
     if singularity_hostname is not None:

--- a/jetstream/backends/slurm_singularity.py
+++ b/jetstream/backends/slurm_singularity.py
@@ -673,8 +673,9 @@ async def sbatch(cmd, singularity_image, singularity_executable="singularity",
         singularity_run_env_vars += f"""SINGULARITY_DOCKER_USERNAME='$oauthtoken' SINGULARITY_DOCKER_PASSWORD={docker_authentication_token} """
         
     sbatch_script += f"[[ -v SINGULARITY_CACHEDIR ]] || SINGULARITY_CACHEDIR=$HOME/.singularity/cache\n"
-    sbatch_script += f"if ls $SINGULARITY_CACHEDIR/oci-tmp | grep {singularity_image_digest} > /dev/null ; then\n"
-    sbatch_script += f"  {singularity_run_env_vars}{singularity_executable} exec {singularity_exec_args}{singularity_hostname_arg}{singularity_mounts_string} $SINGULARITY_CACHEDIR/oci-tmp/{singularity_image_digest} bash {cmd_script_filename}\n"
+    sbatch_script += f"if find $SINGULARITY_CACHEDIR -type f -name \"{singularity_image_digest}\" | grep \/ > /dev/null ; then\n"
+    sbatch_script += f"  IMAGE_PATH=$(find $SINGULARITY_CACHEDIR -type f -name \"{singularity_image_digest}\")\n"
+    sbatch_script += f"  {singularity_run_env_vars}{singularity_executable} exec {singularity_exec_args}{singularity_hostname_arg}{singularity_mounts_string} $IMAGE_PATH bash {cmd_script_filename}\n"
     sbatch_script += f"else\n"
     sbatch_script += f"  {singularity_run_env_vars}{singularity_executable} exec {singularity_exec_args}{singularity_hostname_arg}{singularity_mounts_string} {singularity_image} bash {cmd_script_filename}\n"
     sbatch_script += f"fi\n"

--- a/jetstream/backends/slurm_singularity.py
+++ b/jetstream/backends/slurm_singularity.py
@@ -552,7 +552,7 @@ async def sbatch(cmd, identity, singularity_image, singularity_executable="singu
     
     mount_strings = []
     for singularity_mount in singularity_mounts:
-        mount_strings.append( "-B %s" % ( singularity_mount ) )
+        mount_strings.append( "--bind %s" % ( singularity_mount ) )
     singularity_mounts_string = " ".join( mount_strings )
     
     # create cmd script
@@ -660,7 +660,7 @@ async def sbatch(cmd, identity, singularity_image, singularity_executable="singu
         else:
             singularity_args.extend(runner_args)
 
-    singularity_exec_args = "--cleanenv --contain"
+    singularity_exec_args = "--bind $PWD --pwd $PWD --cleanenv --contain"
     
     for arg in singularity_args:
         singularity_exec_args += f"{arg} " 

--- a/jetstream/tasks.py
+++ b/jetstream/tasks.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 IDENTITY = (
     'cmd',
     'exec',
-    'container'
+    'container',
     'digest'
 )
 

--- a/jetstream/workflows.py
+++ b/jetstream/workflows.py
@@ -513,9 +513,9 @@ def mash(G, H):
 
     log.info(
         'Mash report:\n'
-        f'New tasks: {new}\n'
-        f'Modified tasks: {modified}\n'
-        f'Final: {workflow.summary()}'
+        f'Tasks added: {new}\n'
+        f'Tasks modified: {modified}\n'
+        f'Final workflow status: {workflow.summary()}'
     )
 
     return workflow


### PR DESCRIPTION
This fixes a handful of issues:

- Easy solution for #116
- This also handles this issue from a downstream pipeline - https://github.com/tgen/tempe/issues/10
  - By using the identity of the task for the slurm_singularity backend generated files, we avoid the potential for a sample.name or any user supplied variable generating a task name that is longer than 255 characters.
- Better containerization of the slurm_singularity backend, using `--contain` ensures that we don't bind /home or any other directories defined in the singularity.conf unless we explicitly bind them
  - We also only use `--nv` if CUDA_VISIBLE_DEVICES is defined, some users have been misled into thinking that the warning thrown when on a non-gpu box is a job breaking error.
