### PR TITLE
Jetstream v1.7.3 features

### DIFF
--- a/jetstream/backends/slurm.py
+++ b/jetstream/backends/slurm.py
@@ -40,7 +40,7 @@ class SlurmBackend(BaseBackend):
             sbatch_args=None,
             sbatch_delay=0.1,
             sbatch_executable=None,
-            sacct_fields=('JobID', 'Elapsed'),
+            sacct_fields=('JobID', 'Elapsed', 'State', 'ExitCode'),
             job_monitor_max_fails=5):
         """SlurmBackend submits tasks as jobs to a Slurm batch cluster
 
@@ -128,7 +128,7 @@ class SlurmBackend(BaseBackend):
                     self._bump_next_update()
                     continue
                 try:
-                    sacct_data = sacct(*self.jobs, return_data=True)
+                    sacct_data = sacct(*self.jobs, self.sacct_fields, return_data=True)
                 except Exception:
                     if failures <= 0:
                         raise
@@ -333,10 +333,10 @@ class SlurmBatchJob(object):
             return False
 
 
-def wait(*job_ids, update_frequency=10):
+def wait(*job_ids, sacct_fields, update_frequency=10):
     """Wait for one or more slurm batch jobs to complete"""
     while 1:
-        jobs = sacct(*job_ids)
+        jobs = sacct(*job_ids, sacct_fields)
 
         if all([j.is_done() for j in jobs]):
             return
@@ -344,7 +344,7 @@ def wait(*job_ids, update_frequency=10):
             time.sleep(update_frequency)
 
 
-def sacct(*job_ids, chunk_size=1000, strict=False, return_data=False):
+def sacct(*job_ids, sacct_fields, chunk_size=1000, strict=False, return_data=False):
     """Query sacct for job records.
 
     Jobs are returned for each job id, but steps will be combined under a
@@ -361,7 +361,7 @@ def sacct(*job_ids, chunk_size=1000, strict=False, return_data=False):
     data = {}
     for i in range(0, len(job_ids), chunk_size):
         chunk = job_ids[i: i + chunk_size]
-        sacct_output = launch_sacct(*chunk)
+        sacct_output = launch_sacct(*chunk, sacct_fields)
         data.update(sacct_output)
 
     log.debug('Status updates for {} jobs'.format(len(data)))
@@ -381,7 +381,7 @@ def sacct(*job_ids, chunk_size=1000, strict=False, return_data=False):
     return jobs
 
 
-def launch_sacct(*job_ids, delimiter=SLURM_SACCT_DELIMITER, raw=False):
+def launch_sacct(*job_ids, sacct_fields, delimiter=SLURM_SACCT_DELIMITER, raw=False):
     """Launch sacct command and return stdout data
 
     This function returns raw query results, sacct() will be more
@@ -393,7 +393,7 @@ def launch_sacct(*job_ids, delimiter=SLURM_SACCT_DELIMITER, raw=False):
     :return: Dict or Bytes
     """
     log.debug('Sacct request for {} jobs...'.format(len(job_ids)))
-    args = ['sacct', '-P', '--format', 'all', '--delimiter={}'.format(delimiter)]
+    args = ['sacct', '-P', '--format', '{}'.format(','.join(sacct_fields)), '--delimiter={}'.format(delimiter)]
 
     for jid in job_ids:
         args.extend(['-j', str(jid)])

--- a/jetstream/backends/slurm.py
+++ b/jetstream/backends/slurm.py
@@ -129,7 +129,7 @@ class SlurmBackend(BaseBackend):
                     self._bump_next_update()
                     continue
                 try:
-                    sacct_data = sacct(*self.jobs, self.sacct_fields, return_data=True)
+                    sacct_data = sacct(*self.jobs, sacct_fields=self.sacct_fields, return_data=True)
                 except Exception:
                     if failures <= 0:
                         raise
@@ -337,10 +337,10 @@ class SlurmBatchJob(object):
             return False
 
 
-def wait(*job_ids, sacct_fields, update_frequency=10):
+def wait(*job_ids, sacct_fields=None, update_frequency=10):
     """Wait for one or more slurm batch jobs to complete"""
     while 1:
-        jobs = sacct(*job_ids, sacct_fields)
+        jobs = sacct(*job_ids, sacct_fields=sacct_fields)
 
         if all([j.is_done() for j in jobs]):
             return
@@ -348,7 +348,7 @@ def wait(*job_ids, sacct_fields, update_frequency=10):
             time.sleep(update_frequency)
 
 
-def sacct(*job_ids, sacct_fields, chunk_size=1000, strict=False, return_data=False):
+def sacct(*job_ids, sacct_fields=None, chunk_size=1000, strict=False, return_data=False):
     """Query sacct for job records.
 
     Jobs are returned for each job id, but steps will be combined under a
@@ -365,7 +365,7 @@ def sacct(*job_ids, sacct_fields, chunk_size=1000, strict=False, return_data=Fal
     data = {}
     for i in range(0, len(job_ids), chunk_size):
         chunk = job_ids[i: i + chunk_size]
-        sacct_output = launch_sacct(*chunk, sacct_fields)
+        sacct_output = launch_sacct(*chunk, sacct_fields=sacct_fields)
         data.update(sacct_output)
 
     log.debug('Status updates for {} jobs'.format(len(data)))
@@ -385,7 +385,7 @@ def sacct(*job_ids, sacct_fields, chunk_size=1000, strict=False, return_data=Fal
     return jobs
 
 
-def launch_sacct(*job_ids, sacct_fields, delimiter=SLURM_SACCT_DELIMITER, raw=False):
+def launch_sacct(*job_ids, sacct_fields=None, delimiter=SLURM_SACCT_DELIMITER, raw=False):
     """Launch sacct command and return stdout data
 
     This function returns raw query results, sacct() will be more

--- a/jetstream/backends/slurm.py
+++ b/jetstream/backends/slurm.py
@@ -3,6 +3,7 @@ import itertools
 import json
 import logging
 import os
+import sys
 import re
 import shlex
 import shutil
@@ -228,7 +229,10 @@ class SlurmBackend(BaseBackend):
         self._bump_next_update()
         log.info(f'SlurmBackend submitted({job.jid}): {task.name}')
 
-        job.event = asyncio.Event()
+        if sys.version_info > (3, 8):
+            job.event = asyncio.Event()
+        else:
+            job.event = asyncio.Event(loop=self.runner.loop)
         self.jobs[job.jid] = job
 
         await job.event.wait()

--- a/jetstream/backends/slurm.py
+++ b/jetstream/backends/slurm.py
@@ -228,7 +228,7 @@ class SlurmBackend(BaseBackend):
         self._bump_next_update()
         log.info(f'SlurmBackend submitted({job.jid}): {task.name}')
 
-        job.event = asyncio.Event(loop=self.runner.loop)
+        job.event = asyncio.Event()
         self.jobs[job.jid] = job
 
         await job.event.wait()

--- a/jetstream/backends/slurm_singularity.py
+++ b/jetstream/backends/slurm_singularity.py
@@ -668,8 +668,9 @@ async def sbatch(cmd, identity, singularity_image, singularity_executable="singu
 
     singularity_exec_args = "--bind $JS_PIPELINE_PATH --bind $PWD --pwd $PWD --workdir /tmp --cleanenv --contain"
 
-    if any('gpu' in s for s in singularity_args):
-        singularity_exec_args += ' --nv'
+    if any('gpu' in s for s in [singularity_args, sbatch_args]):
+        if all('--nv' not in s for s in singularity_args):
+            singularity_exec_args += ' --nv'
 
     for arg in singularity_args:
         singularity_exec_args += f" {arg}" 

--- a/jetstream/backends/slurm_singularity.py
+++ b/jetstream/backends/slurm_singularity.py
@@ -64,7 +64,7 @@ class SlurmSingularityBackend(BaseBackend):
         self.job_monitor_max_fails = job_monitor_max_fails
         self.max_jobs = max_jobs
         self.jobs = dict()
-        self.input_file_validation = settings['backends']['slurm_singularity']['input_file_validation'].get()
+        self.input_file_validation = input_file_validation
 
         self.coroutines = (self.job_monitor,)
         self._next_update = datetime.now()

--- a/jetstream/backends/slurm_singularity.py
+++ b/jetstream/backends/slurm_singularity.py
@@ -301,7 +301,7 @@ class SlurmSingularityBackend(BaseBackend):
         self._bump_next_update()
         log.info(f'SlurmSingularityBackend submitted({job.jid}): {task.name}')
 
-        job.event = asyncio.Event(loop=self.runner.loop)
+        job.event = asyncio.Event()
         self.jobs[job.jid] = job
 
         await job.event.wait()

--- a/jetstream/backends/slurm_singularity.py
+++ b/jetstream/backends/slurm_singularity.py
@@ -4,7 +4,7 @@ import itertools
 import json
 import logging
 import os
-import random
+import sys
 import re
 import shlex
 import shutil
@@ -301,7 +301,10 @@ class SlurmSingularityBackend(BaseBackend):
         self._bump_next_update()
         log.info(f'SlurmSingularityBackend submitted({job.jid}): {task.name}')
 
-        job.event = asyncio.Event()
+        if sys.version_info > (3, 8):
+            job.event = asyncio.Event()
+        else:
+            job.event = asyncio.Event(loop=self.runner.loop)
         self.jobs[job.jid] = job
 
         await job.event.wait()

--- a/jetstream/cli/subcommands/run.py
+++ b/jetstream/cli/subcommands/run.py
@@ -140,6 +140,8 @@ def run(wf, args):
     if args.mash_only:
         if args.out:
             wf.save(args.out)
+        else:
+            wf.save()
         log.info('Mashed workflow built successfully!')
         return
 

--- a/jetstream/config_default.yaml
+++ b/jetstream/config_default.yaml
@@ -86,10 +86,33 @@ backends:
     (): jetstream.backends.local.LocalBackend
     blocking_io_penalty: 30
     cpus: null
+  local_docker:
+    (): jetstream.backends.local_docker.LocalDockerBackend
+  local_singularity:
+    (): jetstream.backends.local_singularity.LocalSingularityBackend
+    pullfolder: null
   slurm:
     (): jetstream.backends.slurm.SlurmBackend
     job_monitor_max_fails: 5
-    sacct_frequency: 10
+    sacct_frequency: 60
+    sacct_fields:
+      - JobID
+      - JobName
+      - Partition
+      - Account
+      - AllocCPUS
+      - State
+      - ExitCode
+      - Elapsed
+      - ElapsedRaw
+      - Start
+      - End
+      - MaxRSS
+  slurm_singularity:
+    (): jetstream.backends.slurm_singularity.SlurmSingularityBackend
+    sbatch_account: null
+    input_file_validation: false
+    sacct_frequency: 60
     sacct_fields:
       - JobID
       - JobName
@@ -105,15 +128,6 @@ backends:
       - MaxRSS
   dnanexus:
     (): jetstream.backends.dnanexus.DnanexusBackend
-  local_docker:
-    (): jetstream.backends.local_docker.LocalDockerBackend
-  local_singularity:
-    (): jetstream.backends.local_singularity.LocalSingularityBackend
-    pullfolder: null
-  slurm_singularity:
-    (): jetstream.backends.slurm_singularity.SlurmSingularityBackend
-    sbatch_account: null
-    input_file_validation: false
 
 
 # This option controls the number of times the runner will attempt to
@@ -157,13 +171,10 @@ slurm_solo_options:
   - --wait
 
 slurm_presets:
-  example:
-    - -p
-    - defq
+  example: ['-p', 'defq']
 
 singularity_presets:
-  example:
-    - null
+  example: []
 
 # ================================== Pipelines ================================
 # Pipelines are a collection of pre-built workflows that are installed in the

--- a/jetstream/pipelines.py
+++ b/jetstream/pipelines.py
@@ -134,6 +134,7 @@ class Pipeline:
             bin_path = os.path.join(self.path, bin_path)
             new_path = f'{bin_path}:{os.environ["PATH"]}'
             os.environ['PATH'] = new_path
+            os.environ['SINGULARITYENV_APPEND_PATH'] = bin_path
 
         if self.env:
             for k, v in self.env.items():

--- a/jetstream/templates.py
+++ b/jetstream/templates.py
@@ -105,6 +105,17 @@ def sha256(value):
     return h.hexdigest()
 
 
+def md5(path):
+    """Allow "{{ path|md5 }}" to be used in templates. A good
+    use case is to track the md5sum of a script or other file that may
+    change over time. Causing the render to update on file change"""
+    hash_md5 = hashlib.md5()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            hash_md5.update(chunk)
+    return hash_md5.hexdigest()
+
+
 def fromjson(value):
     """Allow "{{ value|fromjson }}" to be used in templates"""
     return json.loads(value)
@@ -151,6 +162,7 @@ def environment(*searchpath, strict=True, trim_blocks=True, lstrip_blocks=True):
     env.filters['dirname'] = dirname
     env.filters['urlparse'] = urlparse
     env.filters['sha256'] = sha256
+    env.filters['md5'] = md5
     return env
 
 

--- a/jetstream/templates.py
+++ b/jetstream/templates.py
@@ -116,6 +116,22 @@ def md5(path):
     return hash_md5.hexdigest()
 
 
+def assignbin(value, bins=[0, float('inf')], labels=None):
+    """Allow "{{ value|assignbin }}" to be used in templates. The return value
+    of this filter is the 0-based bin the value falls in. Default bin is 0 to
+    infinity. Edges floor to lower bin. Also accepts a list of labels such
+    that: assignbin(5,[0,2,4,6],['low','med','high']) }} returns 'high'.
+    Returns -1 if the value is out of bounds."""
+    start = bins[:-1]
+    end = bins[1:]
+    for i, (lower_bound, upper_bound) in enumerate(zip(start, end)):
+        if lower_bound <= value <= upper_bound:
+            if labels is not None:
+                return labels[i]
+            return i
+    return -1
+
+
 def fromjson(value):
     """Allow "{{ value|fromjson }}" to be used in templates"""
     return json.loads(value)
@@ -163,6 +179,7 @@ def environment(*searchpath, strict=True, trim_blocks=True, lstrip_blocks=True):
     env.filters['urlparse'] = urlparse
     env.filters['sha256'] = sha256
     env.filters['md5'] = md5
+    env.filters['assignbin'] = assignbin
     return env
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ MarkupSafe==2.1.1
 networkx>=2.6
 PyYAML>=5.4
 ulid-py==1.1.0
+packaging==21.3


### PR DESCRIPTION
The list of updates here is relatively concise:
- For slurm backends, the `sacct` pinginess has been reduced, and we request less information install of `--all`, this reduces load on the slurmdbd
- The slurm_singularity backend can now submit jobs without a container definition
  - It might makes sense to merge the slurm backends in this case though we'd also need to integrate docker as an alternative container runner
- Not all asyncio.Event(loop)'s were fixed in previous commits, this should fix other cases impeding us from using python 3.10 https://github.com/tgen/jetstream/issues/144
- Added an `md5` and `assignbin` filter for using in templates
  - Resolves https://github.com/tgen/jetstream/issues/101
- Adjusted handling of gpu jobs, we now set `SINGULARITYENV_CUDA_VISIBLE_DEVICES`