### PR TITLE
Updates to follow pep 440 versioning for pipelines

### DIFF
--- a/jetstream/cli/subcommands/pipelines.py
+++ b/jetstream/cli/subcommands/pipelines.py
@@ -10,7 +10,6 @@ Pipeline names may also include a version number <name>@<version>.
 For complete option listing see "jetstream run" """
 import logging
 import sys
-import errno
 import jetstream
 from jetstream.cli.subcommands import run_common_options, run
 
@@ -43,28 +42,20 @@ def main(args):
         searchpath = args.search_path
     else:
         searchpath = jetstream.settings['pipelines']['searchpath'].get()
-        searchpath = searchpath.split(':')
+        searchpath = searchpath.split(':') 
 
     # load and describe pipeline
     if args.verbose and args.pipeline:
         # Direct pipeline path given, just load and show details
         ctx = args.pipeline.get_context()
-        try:
-            jetstream.utils.dump_yaml(ctx, sys.stdout)
-        except IOError as e:
-            if e.errno == errno.EPIPE:
-                pass
+        jetstream.utils.dump_yaml(ctx, sys.stdout)
     elif args.verbose and args.name:
         # Find a pipeline and show details
         pipeline, *version = args.name.rsplit('@', 1)
         version = next(iter(version), None)
         args.pipeline = jetstream.get_pipeline(pipeline, version, searchpath=searchpath)
         ctx = args.pipeline.get_context()
-        try:
-            jetstream.utils.dump_yaml(ctx, sys.stdout)
-        except IOError as e:
-            if e.errno == errno.EPIPE:
-                pass
+        jetstream.utils.dump_yaml(ctx, sys.stdout)
     elif args.pipeline:
         # Direct pipeline path give, just load and run
         run.main(args)
@@ -78,8 +69,4 @@ def main(args):
         # List all pipelines
         all_pipelines = jetstream.list_pipelines(*searchpath)
         output = '\n'.join(f'{p.name} ({p.version}): {p.path}' for p in all_pipelines)
-        try:
-            print(output)
-        except IOError as e:
-            if e.errno == errno.EPIPE:
-                pass
+        print(output)

--- a/jetstream/pipelines.py
+++ b/jetstream/pipelines.py
@@ -229,5 +229,5 @@ def is_pipeline(path):
 
 
 def list_pipelines(*dirs):
-    """Returns all pipelines found as a list"""
-    return list(find_pipelines(*dirs))
+    """Returns all pipelines found as a sorted list"""
+    return list(sorted(find_pipelines(*dirs), key=lambda p: parse_pipeline_version(p.version)))

--- a/jetstream/pipelines.py
+++ b/jetstream/pipelines.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from packaging.version import parse as parse_version
+from packaging.version import parse
 import jetstream
 
 log = logging.getLogger(__name__)
@@ -69,10 +69,10 @@ class Pipeline:
         return f'<Pipeline {self.name} ({self.version}): {self.path}>'
 
     def __lt__(self, other):
-        return (self.name, parse_pipeline_version(self.version)) < (other.name, parse_pipeline_version(other.version))
+        return (self.name, parse_version(self.version)) < (other.name, parse_version(other.version))
 
     def __eq__(self, other):
-        return (self.name, parse_pipeline_version(self.version)) == (other.name, parse_pipeline_version(other.version))
+        return (self.name, parse_version(self.version)) == (other.name, parse_version(other.version))
 
     def get_context(self):
         ctx = self.manifest.copy()
@@ -176,7 +176,7 @@ def find_pipelines(*dirs):
                 yield from find_pipelines(path)
 
 
-def parse_pipeline_version(version):
+def parse_version(version):
     """
     Pipeline versions generally should not use epochs however if an epoch is used, then it
     should be less than 999 as in other words that means we had 999 versioning format changes
@@ -189,9 +189,9 @@ def parse_pipeline_version(version):
     2014.04           1!2.0
     """
     if version in ["dev", "develop", "development"]:
-        return parse_version("999!9.dev")
+        return parse("999!9.dev")
     else:
-        return parse_version(version)
+        return parse(str(version))
 
 
 def get_pipeline(name, version=None, searchpath=None):
@@ -208,11 +208,11 @@ def get_pipeline(name, version=None, searchpath=None):
                 matches.append(p)
 
         if matches:
-            s = sorted(matches, key=lambda p: parse_pipeline_version(p.version))
+            s = sorted(matches, key=lambda p: parse_version(p.version))
             if version in [None, "latest"]:
-                return max([p for p in s if not parse_pipeline_version(p.version).is_devrelease])
+                return max([p for p in s if not parse_version(p.version).is_devrelease])
             else:
-                return max([p for p in s if parse_pipeline_version(p.version).is_devrelease])
+                return max([p for p in s if parse_version(p.version).is_devrelease])
     else:
         # Find a match with name and version
         for p in find_pipelines(*searchpath):


### PR DESCRIPTION
Updates to follow pep 440 versioning for pipelines, this is close to how we have been versioning the pipelines already, but now we will better support the usage of the dev, alpha, beta, and rc identifiers; additionally, versions with and without `v`. Along with this, we now can use `development` as an alias to grabbing the most recent dev version of a pipeline. Legacy pipelines that are using `development` as their version will still be considered as the most recent dev version, otherwise the sort order is largely the same a before.

This also fixes a bug that pops up with using packaging >= 22.0, as in this version range `development` is not a valid version. We override this behavior and say that `development` is the highest version possible and is still considered as a dev version.

For example if given the following versions:
```
1.0.0
1.1.2
1.1.3.dev
```

We should now expect the following behavior:
```
jetstream pipelines somepipeline@1.0.0		## Returns 1.0.0
jetstream pipelines somepipeline@v1.0.0		## Also returns 1.0.0
jetstream pipelines somepipeline@latest		## Returns 1.1.2
jetstream pipelines somepipeline@dev		## Returns 1.1.3.dev
```
---
If we still have legacy versions, e.g.:
```
v0.9.1
 1.0.0
 1.1.2
 1.1.3.dev
development
```
we expect the following behavior:
```
jetstream pipelines somepipeline@0.9.1		## Returns v0.9.1
jetstream pipelines somepipeline@v1.0.0		## Returns 1.0.0
jetstream pipelines somepipeline@latest		## Returns 1.1.2
jetstream pipelines somepipeline@dev		## Returns development
```


Finally, `jetstream pipelines` will now return a sorted list, previously this was somewhat random as there was not a function for identifying if one version was greater than the other in terms of sort order. This is fixed by adding `__eq__` and `__lt__`.