### PR TITLE
Bug fix for binding JS_PIPELINE_PATH differences between run and pipelines

### DIFF
--- a/jetstream/backends/slurm_singularity.py
+++ b/jetstream/backends/slurm_singularity.py
@@ -666,14 +666,16 @@ async def sbatch(cmd, identity, singularity_image, singularity_executable="singu
         else:
             singularity_args.extend(runner_args)
 
-    singularity_exec_args = "--bind $JS_PIPELINE_PATH --bind $PWD --pwd $PWD --workdir /tmp --cleanenv --contain"
+    singularity_exec_args = "--bind $PWD --pwd $PWD --workdir /tmp --cleanenv --contain"
+    if os.getenv('JS_PIPELINE_PATH') is not None:
+        singularity_exec_args += " --bind " + os.getenv('JS_PIPELINE_PATH')
 
     if any('gpu' in s for s in [singularity_args, sbatch_args]):
         if all('--nv' not in s for s in singularity_args):
             singularity_exec_args += ' --nv'
 
     for arg in singularity_args:
-        singularity_exec_args += f" {arg}" 
+        singularity_exec_args += f" {arg}"
 
     singularity_hostname_arg = ""
     if singularity_hostname is not None:

--- a/jetstream/backends/slurm_singularity.py
+++ b/jetstream/backends/slurm_singularity.py
@@ -668,7 +668,8 @@ async def sbatch(cmd, identity, singularity_image, singularity_executable="singu
 
     singularity_exec_args = "--bind $PWD --pwd $PWD --workdir /tmp --cleanenv --contain"
     if os.getenv('JS_PIPELINE_PATH') is not None:
-        singularity_exec_args += " --bind " + os.getenv('JS_PIPELINE_PATH')
+        singularity_exec_args += " --bind {}".format(os.getenv('JS_PIPELINE_PATH'))
+        sbatch_script += "export SINGULARITYENV_JS_PIPELINE_PATH={}\n".format(os.getenv('JS_PIPELINE_PATH'))
 
     if any('gpu' in s for s in [singularity_args, sbatch_args]):
         if all('--nv' not in s for s in singularity_args):

--- a/jetstream/backends/slurm_singularity.py
+++ b/jetstream/backends/slurm_singularity.py
@@ -692,8 +692,8 @@ async def sbatch(cmd, identity, singularity_image, singularity_executable="singu
         # We set the SINGULARITY_CACHEDIR to the default if it isn't defined by the user
         sbatch_script += f"[[ -v SINGULARITY_CACHEDIR ]] || SINGULARITY_CACHEDIR=$HOME/.singularity/cache\n"
         # Searching for the cached image and using it if it exists
-        sbatch_script += f"for file in $(find $SINGULARITY_CACHEDIR -type f -name \"{singularity_image_digest}\"); do\n"
-        sbatch_script += f"  {singularity_executable} inspect $file > /dev/null 2>&1 && IMAGE_PATH=$file\n"
+        sbatch_script += f"for file in $(find $SINGULARITY_CACHEDIR/oci-tmp -type f); do\n"
+        sbatch_script += f"  {singularity_executable} inspect $file 2> /dev/null | grep -E '{singularity_image_digest}|{singularity_image}' && IMAGE_PATH=$file && break\n"
         sbatch_script += f"done\n"
         sbatch_script += f"if [[ -v IMAGE_PATH ]] ; then\n"
         sbatch_script += f"  {singularity_run_env_vars}{singularity_executable} exec {singularity_exec_args} {singularity_hostname_arg}{singularity_mounts_string} $IMAGE_PATH bash {cmd_script_filename}\n"


### PR DESCRIPTION
This fixes the handling of JS_PIPELINE_PATH within the slurm_singularity backend, namely due to the fact that `jetstream run` does not set `JS_PIPELINE_PATH` at runtime unless `--pipeline` is defined. The slurm_singularity backend was assuming that this value was always populated and would attempt to bind it by default within singularity.

Now, we check to see if `JS_PIPELINE_PATH` is in the environment and handle the export accordingly. Additionally, this PR adds in some bash variable expansion as well as replacing `JS_PIPELINE_PATH` with `__pipeline__.path` when necessary (within functions such as `md5`). Variable expansion is via `os.path.expandvars()`, and since `JS_PIPELINE_PATH` doesn't exist in the environment until runtime, we pass the pipeline context to the `md5` function.

Finally, this also has adjustments for finding containers/images that are already in the cache dir. We previously only found images if the `digest` was defined for the task. Technically `digest` is an optional, but recommended directive. So now we search the cache dir within the job submission before attempting to pull externally. Theoretically, we should always find the image in the cache, but it's possible the cache has been cleaned since the start of the project and we want to avoid failures in these cases if possible.