### PR TITLE
Small update to slurm_singularity's auto gpu detection and configuring setup.py to use networkx>=2.6,<3

### DIFF
--- a/jetstream/backends/slurm_singularity.py
+++ b/jetstream/backends/slurm_singularity.py
@@ -673,8 +673,8 @@ async def sbatch(cmd, identity, singularity_image, singularity_executable="singu
         singularity_exec_args += " --bind {}".format(os.getenv('JS_PIPELINE_PATH'))
         sbatch_script += "export SINGULARITYENV_JS_PIPELINE_PATH={}\n".format(os.getenv('JS_PIPELINE_PATH'))
 
-    if any('gpu' in s for s in [singularity_args, sbatch_args]):
-        if all('--nv' not in s for s in singularity_args):
+    if 'gpu' in ' '.join(map(str, sbatch_args)):
+        if '--nv' not in singularity_exec_args:
             singularity_exec_args += ' --nv'
 
     for arg in singularity_args:

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'Topic :: Utilities',
     ],
     install_requires=[
-        'networkx',
+        'networkx>=2.6,<3',
         'pyyaml',
         'ulid-py',
         'jinja2>=3.0.0',


### PR DESCRIPTION
Small update to slurm_singularity's auto gpu detection and configuring setup.py to use networkx>=2.6,<3.

The gpu detection is a nice to have, but not required since the pipeline designer can and should `--nv` as part of the runner_args. 

Networkx typically supports 3-4 major python releases, networkx 3.0 supports 3.8, 3.9, 3.10, and 3.11, which overlaps our supported python versions, but it adds the following change that impacts our usage:
> If you use the presence of the attribute `_adj` as a criteria for the object being a Graph instance, that code may need updating. The graph classes themselves now have an attribute `_adj`. So, it is possible that whatever you are checking might be a class rather than an instance.

We will plan to migrate networkx 3.x in a future jetstream release - particularly as certain python versions approach EOL.